### PR TITLE
changed text_input default text to placeholder text

### DIFF
--- a/tutorial.py
+++ b/tutorial.py
@@ -94,7 +94,7 @@ st.write("You selected", len(hobbies), 'hobbies')
 # save the input text in the variable 'name'
 # first argument shows the title of the text input box
 # second argument displays a default text inside the text input area
-name = st.text_input("Enter Your name", "Type Here ...")
+name = st.text_input("Enter Your name", placeholder="Type Here ...")
 
 # display the name when the submit button is clicked
 # .title() is used to get the input text string


### PR DESCRIPTION
Using placeholder text allows a user to start typing in the text box without dealing with the placeholder text - it just disappears as soon as the user starts typing. And if there is already text in the box from a previous recall of data or even later added default text, the placeholder text does not appear.